### PR TITLE
1631303 public cloud programme bug

### DIFF
--- a/templates/block/_logo-list.html
+++ b/templates/block/_logo-list.html
@@ -1,5 +1,5 @@
 {% if programme_partners %}
-<section class="row {% if extra_class %} {{ extra_class }}{% endif %}">
+<section class="row {% if extra_class %}{{ extra_class }}{% endif %}">
     <div class="twelve-col">
         <h3 class="caps-centered">A selection of our {{ name }}</h3>
         <div class="list-auto twelve-col">

--- a/templates/programmes/public-cloud.html
+++ b/templates/programmes/public-cloud.html
@@ -54,7 +54,7 @@
     </div>
 </div>
 
-{% include "block/_logo-list.html" with name="public cloud partners" extra_class="no-border" query="programme=certified-public-cloud" %}
+{% include "block/_logo-list.html" with name="public cloud partners" query="programme=certified-public-cloud" extra_class="no-border" %}
 
 {% include "templates/_contextual-footer.html" %}
 

--- a/templates/templates/_contextual-footer.html
+++ b/templates/templates/_contextual-footer.html
@@ -32,8 +32,8 @@
             <div class="feature-two six-col last-col">
                 <h3>Further reading</h3>
                 <ul class="no-bullets">
-                  <li><a class="external" href="http://insights.ubuntu.com/2016/02/21/charm-partner-programme/">Ubuntu Certified Public Cloud programme datasheet</a></li>
-                  <li><a class="external" href="http://insights.ubuntu.com/2016/06/01/ebook-certified-ubuntu-cloud-guest/">Certified Ubuntu Cloud Guest eBook</a></li>
+                  <li><a class="external" href="http://insights.ubuntu.com/2016/10/07/ubuntu-certified-public-cloud-programme-2/">Ubuntu Certified Public Cloud programme datasheet</a></li>
+                  <li><a class="external" href="http://insights.ubuntu.com/2016/01/14/5-reasons-you-should-only-use-certified-images-on-the-public-cloud/">Certified Ubuntu Cloud Guest eBook</a></li>
                 </ul>
             </div>
         {% else %}


### PR DESCRIPTION
## Done

On /programmes/public-cloud: 

* fixed the logo cloud include to show the query in the See all public cloud partners › link
* fixed the urls in the further reading section

## QA

1. go to /programmes/public-cloud See all public cloud partners › link goes to /find-a-partner?programme=certified-public-cloud
2. see that the Further reading links to the correct insights posts
 * http://insights.ubuntu.com/2016/10/07/ubuntu-certified-public-cloud-programme-2/
 * http://insights.ubuntu.com/2016/01/14/5-reasons-you-should-only-use-certified-images-on-the-public-cloud/

## Issue / Card

[Launchpad bug  1631303](https://bugs.launchpad.net/ubuntu-website-content/+bug/1631303)

