### PR TITLE
database migration for HTTPS logos

### DIFF
--- a/cms/migrations/0005_https_logos.py
+++ b/cms/migrations/0005_https_logos.py
@@ -1,0 +1,33 @@
+# Modules
+from django.db import migrations
+
+# Local
+from cms.models import Partner
+from urlparse import urlparse, urlunparse
+
+
+def update_logo_urls(apps, schema_editor):
+    partners = Partner.objects.all()
+
+    for partner in partners:
+        (scheme, netloc, path, params, query, fragment) = urlparse(
+            partner.logo
+        )
+
+        if scheme == 'http' and netloc == 'assets.ubuntu.com':
+            new_url = urlunparse(
+                ('https', netloc, path, params, query, fragment)
+            )
+
+            partner.logo = new_url
+            partner.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('cms', '0004_auto_20160331_1555'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_logo_urls)
+    ]


### PR DESCRIPTION
We need all logos that are on the assets server to use an HTTPS protocol, so that they don't break other HTTPS websites when pulled in through feeds.

QA
---

First roll back to how it was before my commit and setup the database:

``` bash
$ git rev-parse HEAD
81b00e6d2c84460f595cb3788264c2558acdeeb7  # Remember this
$ git reset --hard HEAD^
$ ./run clean
$ ./run docker-compose run webapp migrate
$ ./run docker-compose run webapp loaddata partners.json
$ ./run
```

Go to <http://127.0.0.1:8003/admin> and see how lots of the logos point to `http://assets.ubuntu.com`.

Now kill the server (`ctrl`+`c`) go back to the top of my PR and run the server again:

``` bash
$ git reset --hard 81b00e6d2c84460f595cb3788264c2558acdeeb7
$ ./run
```

(You should see "`Applying cms.0005_https_logos... OK`" fly past)

Now go to <http://127.0.0.1:8003/admin> again. You should see that there are no longer any `http://assets.ubuntu.com`s, instead they're all `https://assets.ubuntu.com`.