### PR TITLE
Correct partner capitalisation

### DIFF
--- a/cms/views.py
+++ b/cms/views.py
@@ -142,7 +142,7 @@ def partner_programmes(request, name):
         ),
 
         "charm": base_partners.filter(
-            programme__name="Charm Partner Programme"
+            programme__name="Charm partner programme"
         ),
     }
     distinct_partners = list(set(lookup_partners[name]))

--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -76,7 +76,7 @@
     <ul class="no-bullets">
         <li  class="mktFormReq mktField">
 <label for="partner_tier__c" class="mktoLabel " >Applying for: <span>*</span></label>
-<select required  id="partner_tier__c" name="partner_tier__c" title="" class="mktoField  mktoRequired" ><option value="">Select...</option><option value="OEM">OEM</option><option value="ODM">ODM</option><option value="ISV">Software (ISV)</option><option value="IHV">Hardware (IHV)</option><option value="SI">Channel Partner / SI</option><option value="Cloud">Ubuntu OpenStack Partner</option><option value="UOIL">Ubuntu OpenStack Interoperability Lab (UOIL)</option><option value="CPP">Charm Partner Programme</option><option value="CPC">Certified Public Cloud</option><option value="Things">Internet of Things</option><option value="Other">Other</option></select>
+<select required  id="partner_tier__c" name="partner_tier__c" title="" class="mktoField  mktoRequired" ><option value="">Select...</option><option value="OEM">OEM</option><option value="ODM">ODM</option><option value="ISV">Software (ISV)</option><option value="IHV">Hardware (IHV)</option><option value="SI">Channel Partner / SI</option><option value="Cloud">Ubuntu OpenStack Partner</option><option value="UOIL">Ubuntu OpenStack interoperability lab (UOIL)</option><option value="CPP">Charm partner programme</option><option value="CPC">Certified Public Cloud</option><option value="Things">Internet of Things</option><option value="Other">Other</option></select>
         </li>
 
         <li  class="mktFormReq mktField">

--- a/templates/programmes/channel.html
+++ b/templates/programmes/channel.html
@@ -11,7 +11,7 @@
 {% block content %}
 <div class="row row-hero equal-height">
     <div class="seven-col">
-        <h1>Ubuntu Channel Partner Programme</h1>
+        <h1>Ubuntu channel partner programme</h1>
         <p>Canonical works with channel partners around the world to ensure that
         local Ubuntu expertise is available on every continent. From OpenStack
         consulting and BootStack managed clouds to hardware sales and Ubuntu

--- a/templates/programmes/charm.html
+++ b/templates/programmes/charm.html
@@ -1,7 +1,7 @@
 {% extends "templates/base_index.html" %}
 
 {% block title %}Ubuntu Charm partners | {% endblock %}
-{% block meta_description %}The Charm Partner Programme, for software vendors, developers and integrators who want to deliver scale-out solutions to their customers on public, private or hybrid clouds{% endblock %}
+{% block meta_description %}The Charm partner programme, for software vendors, developers and integrators who want to deliver scale-out solutions to their customers on public, private or hybrid clouds{% endblock %}
 {% block meta_keywords %}Ubuntu, Canonical, partner, program, programme, partnership, ISV, independent, software, vendor, developer, publisher, application, app, service, global, local, cloud, server,   customer, client, OpenStack, Landscape, Juju, MAAS, IT, provider, open source, Linux, Big Data, cloud orchestration, charm, bundles, solutions, scale, integration, container, LXD, LXC, docker, scale out, bare metal{% endblock %}
 
 {% block second_level_nav_items %}
@@ -12,7 +12,7 @@
 
 <section class="row row-hero equal-height">
     <div class="six-col">
-        <h1>Charm Partner Programme</h1>
+        <h1>Charm partner programme</h1>
         <p>If you&rsquo;re an Independent Software Vendor (ISV)  you know how
         difficult it can be for your customers to realise the full value of your
         software. Releasing your solutions with Juju, the award-winning
@@ -26,7 +26,7 @@
     </div>
 </section>
 
-{% include "block/_logo-list.html" with name="Charm partners" query="programme=charm partner programme" %}
+{% include "block/_logo-list.html" with name="Charm partners" query="programme=Charm partner programme" %}
 
 <section class="row equal-height">
     <div class="seven-col append-one">
@@ -87,7 +87,7 @@
 <section class="row no-border strip-dark">
     <div class="eight-col">
         <h2>What&rsquo;s included?</h2>
-        <p>As a partner involved in the Charm Partner Programme you can expect:</p>
+        <p>As a partner involved in the Charm partner programme you can expect:</p>
     </div>
     <div class="six-col">
         <ul class="list-ubuntu">

--- a/templates/programmes/index.html
+++ b/templates/programmes/index.html
@@ -27,12 +27,12 @@
 
         <div class="four-col box">
             <h3><a href="/programmes/openstack">OpenStack&nbsp;&rsaquo;</a></h3>
-            <p>OpenStack Interoperability Lab is an integration lab in which we test our cloud partners&rsquo; products in countless Ubuntu OpenStack configurations, currently working with over 3,000 combinations per month.</p>
+            <p>OpenStack interoperability lab is an integration lab in which we test our cloud partners&rsquo; products in countless Ubuntu OpenStack configurations, currently working with over 3,000 combinations per month.</p>
         </div>
 
         <div class="four-col last-col box">
             <h3><a href="/programmes/charm">Charm&nbsp;&rsaquo;</a></h3>
-            <p>Our Charm Partner Programme is the fastest route for ISVs and solution providers to take full advantage of all that Juju and the Ubuntu cloud and server ecosystem have to offer.</p>
+            <p>Our Charm partner programme is the fastest route for ISVs and solution providers to take full advantage of all that Juju and the Ubuntu cloud and server ecosystem have to offer.</p>
         </div>
 
     </div><!-- /.equal-height -->

--- a/templates/programmes/openstack.html
+++ b/templates/programmes/openstack.html
@@ -1,7 +1,7 @@
 {% extends "templates/base_index.html" %}
 
-{% block title %}Ubuntu OpenStack Interoperability Lab partners | {% endblock %}
-{% block meta_description %}Engage with the Ubuntu OpenStack Interoperability Lab (Ubuntu OIL) to develop and test your technologies’ interoperability with Ubuntu OpenStack and a range of software and hardware.{% endblock %}
+{% block title %}Ubuntu OpenStack interoperability lab partners | {% endblock %}
+{% block meta_description %}Engage with the Ubuntu OpenStack interoperability lab (Ubuntu OIL) to develop and test your technologies’ interoperability with Ubuntu OpenStack and a range of software and hardware.{% endblock %}
 {% block meta_keywords %}Cloud, OpenStack, Ubuntu, Server, Interoperability, testing, integration, ecosystem, UOIL, development, validation, affiliate, supporter, Technical Partner Progamme, lab, laboratory{% endblock %}
 
 {% block second_level_nav_items %}
@@ -12,8 +12,8 @@
 <div class="row row-hero">
     <img class="priority-0" src="http://assets.ubuntu.com/sites/ubuntu/latest/u/img/cloud/ubuntu-openstack/image-ubuntuopenstack.svg" alt="Ubuntu OpenStack medals">
     <div class="eight-col">
-        <h1>Ubuntu OpenStack Interoperability Lab partners</h1>
-        <p>The Ubuntu OpenStack Interoperability Lab (OIL)  is an integration lab in which we test our cloud partners&rsquo; products in countless Ubuntu OpenStack configurations, over and over again. Currently we are working with over 3,500 combinations per month. </p>
+        <h1>Ubuntu OpenStack interoperability lab partners</h1>
+        <p>The Ubuntu OpenStack interoperability lab (OIL)  is an integration lab in which we test our cloud partners&rsquo; products in countless Ubuntu OpenStack configurations, over and over again. Currently we are working with over 3,500 combinations per month. </p>
     </div>
 </div>
 
@@ -22,7 +22,7 @@
 <div class="row equal-height">
     <div class="seven-col">
         <h2>Proven integration testing</h2>
-        <p>Canonical has a long history of interoperability testing between OpenStack and Ubuntu.  To bring the benefits of our work to the rest of the ecosystem, we’ve launched the Ubuntu OpenStack Interoperability Lab, making it easier for you to QA the compatibility of your products with the world’s leading open cloud platform.</p>
+        <p>Canonical has a long history of interoperability testing between OpenStack and Ubuntu.  To bring the benefits of our work to the rest of the ecosystem, we’ve launched the Ubuntu OpenStack interoperability lab, making it easier for you to QA the compatibility of your products with the world’s leading open cloud platform.</p>
         <h2>A sophisticated testing and integration process</h2>
         <p>Our process tests current and future developments of OpenStack against current and future developments of Ubuntu Server and Server LTS.
         As the ecosystem has grown, we’ve expanded it to include a wide array of guest operating systems, hypervisors, storage technologies,
@@ -31,7 +31,7 @@
         <p>It&rsquo;s never been more important to test your hardware and software against the entire OpenStack ecosystem.  So how do you get involved?</p>
     </div>
     <div class="five-col last-col align-center align-vertically">
-        <img src="https://assets.ubuntu.com/sites/ubuntu/latest/u/img/cloud/ecosystem/ubuntu-oil/image-ubuntuopenstackinteroperabilitylab.svg" alt="Ubuntu OpenStack Interoperability Lab pictograms" class="priority-0">
+        <img src="https://assets.ubuntu.com/sites/ubuntu/latest/u/img/cloud/ecosystem/ubuntu-oil/image-ubuntuopenstackinteroperabilitylab.svg" alt="Ubuntu OpenStack interoperability lab pictograms" class="priority-0">
     </div>
 </div>
 <div class="row no-border strip-dark">

--- a/templates/programmes/software.html
+++ b/templates/programmes/software.html
@@ -56,7 +56,7 @@
         <div class="eight-col no-margin-bottom">
             <h2>Cloud software partners</h2>
             <p>Ubuntu is the world&rsquo;s leading cloud operating system, both as a guest on public clouds &mdash; like Amazon and Windows Azure &mdash; and as a platform on which to build OpenStack clouds.</p>
-            <p>There are two Canonical partner programmes that can help you reach this global market of users and developers: the OpenStack Interoperability Lab and the Charm Partner Programme. Whether you want to improve interoperability in OpenStack, streamline application delivery or simply access more customers, we can help.</p>
+            <p>There are two Canonical partner programmes that can help you reach this global market of users and developers: the OpenStack interoperability lab and the Charm partner programme. Whether you want to improve interoperability in OpenStack, streamline application delivery or simply access more customers, we can help.</p>
         </div>
         <div class="four-col last-col align-center align-vertically">
             <img class="priority-0" width="250" src="https://assets.ubuntu.com/sites/ubuntu/latest/u/img/cloud/image-ecosystem.svg" alt="" />
@@ -68,17 +68,17 @@
           <div class="six-col align-center">
               <img class="priority-0" width="140" height="140" src="https://assets.ubuntu.com/sites/ubuntu/latest/u/img/pictograms/picto-pack/picto-juju.svg" alt="" />
           </div>
-          <h3>Charm Partner Programme</h3>
+          <h3>Charm partner programme</h3>
           <p>Canonical&rsquo;s award-winning service modeling tool, Juju, makes it easy to model, deploy, manage and scale cloud software. With Juju charms, any customer can deploy your products in just a few clicks.</p>
-          <p><a href="/contact-us">Contact us about the Charm Partner Programme&nbsp;&rsaquo;</a></p>
+          <p><a href="/contact-us">Contact us about the Charm partner programme&nbsp;&rsaquo;</a></p>
       </div>
       <div class="six-col last-col" id="openstack-interoperability-lab">
           <div class="six-col align-center">
               <img class="priority-0" width="140" height="140" src="https://assets.ubuntu.com/sites/ubuntu/latest/u/img/pictograms/picto-pack/picto-openstack.svg" alt="" />
           </div>
-          <h3>Openstack Interoperability Lab for Software Partners</h3>
-          <p>In launching the Ubuntu OpenStack Interoperability Lab (OIL), Canonical has invested heavily in interoperability testing for OpenStack and Ubuntu. OIL offers significant benefits for partners looking to QA their products quickly and cost-effectively, ensuring they are are compatible with all versions of Ubuntu OpenStack.</p>
-          <p><a href="/programmes/openstack">Learn more about OpenStack Interoperability Lab&nbsp;&rsaquo;</a></p>
+          <h3>OpenStack interoperability lab for Software Partners</h3>
+          <p>In launching the Ubuntu OpenStack interoperability lab (OIL), Canonical has invested heavily in interoperability testing for OpenStack and Ubuntu. OIL offers significant benefits for partners looking to QA their products quickly and cost-effectively, ensuring they are are compatible with all versions of Ubuntu OpenStack.</p>
+          <p><a href="/programmes/openstack">Learn more about OpenStack interoperability lab&nbsp;&rsaquo;</a></p>
       </div>
   </div>
 </section>

--- a/templates/templates/_contextual-footer.html
+++ b/templates/templates/_contextual-footer.html
@@ -25,7 +25,7 @@
         {% if level_2  == 'charm' %}
             <div class="feature-two six-col last-col">
                 <h3>Further reading</h3>
-                <p><a class="external" href="http://insights.ubuntu.com/2016/02/21/charm-partner-programme/">Charm Partner Programme datasheet</a></p>
+                <p><a class="external" href="http://insights.ubuntu.com/2016/02/21/charm-partner-programme/">Charm partner programme datasheet</a></p>
             </div>
         {% else %}
         {% if level_2  == 'public-cloud' %}


### PR DESCRIPTION
Correct the capitalisation of:

- `OpenStack Interoperability Lab` -> `OpenStack interoperability lab`
- `Charm Partner Programme` -> `Charm partner programme`
- `Ubuntu Channel Partner Programme` -> `Ubuntu channel partner programme`

Fixes #102

# QA
Make sure all instances are changed and they look good.
